### PR TITLE
Handle multiple EXDATE

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -639,7 +639,7 @@ func parseEventRRule(eventData string) string {
 
 func parseExcludedDates(eventData string, convertDatesToUTC bool) ([]time.Time, error) {
 	var dates []time.Time
-	excl := eventExDateRegex.FindAllStringSubmatch(eventData, -1)
+	excl := eventExDateRegex.FindAllStringSubmatch(strings.Replace(eventData, "\n", "", -1), -1)
 
 	for _, e := range excl {
 		if len(e) < 3 {

--- a/parse.go
+++ b/parse.go
@@ -651,23 +651,28 @@ func parseExcludedDates(eventData string, convertDatesToUTC bool) ([]time.Time, 
 			return nil, err
 		}
 
-		dt := strings.TrimSpace(e[2])
-		if !strings.Contains(dt, "Z") {
-			dt += "Z"
+		dts := strings.Split(e[2], ",")
+
+		for _, dt := range dts {
+			dt = strings.TrimSpace(dt)
+
+			if !strings.Contains(dt, "Z") {
+				dt += "Z"
+			}
+
+			t, err := time.Parse(icsFormat, dt)
+			if err != nil {
+				return nil, err
+			}
+
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), tz)
+
+			if convertDatesToUTC {
+				t = t.UTC()
+			}
+
+			dates = append(dates, t)
 		}
-
-		t, err := time.Parse(icsFormat, dt)
-		if err != nil {
-			return nil, err
-		}
-
-		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), tz)
-
-		if convertDatesToUTC {
-			t = t.UTC()
-		}
-
-		dates = append(dates)
 	}
 
 	return dates, nil


### PR DESCRIPTION
The EXDATE property can be defined multiple times by having only one
clause with dates separated by commas.
(e.g.: `EXDATE;TZID=Pacific Standard Time:20180504T133000,20180601T133000`)