### PR TITLE
Date/Time parsing tweak

### DIFF
--- a/event.go
+++ b/event.go
@@ -25,6 +25,8 @@ type Event struct {
 	Organizer     Attendee
 	WholeDayEvent bool
 	ExDates       []time.Time
+	StartTimezone *time.Location
+	EndTimezone   *time.Location
 }
 
 type byDate []Event

--- a/parse.go
+++ b/parse.go
@@ -662,23 +662,27 @@ func parseExcludedDates(eventData string, convertDatesToUTC bool) ([]time.Time, 
 			return nil, err
 		}
 
-		dt := strings.TrimSpace(e[2])
-		if !strings.Contains(dt, "Z") {
-			dt += "Z"
+		exDates := strings.Split(e[2], ",")
+
+		for _, dateStr := range exDates {
+			dt := strings.TrimSpace(dateStr)
+			if !strings.Contains(dt, "Z") {
+				dt += "Z"
+			}
+
+			t, err := time.Parse(icsFormat, dt)
+			if err != nil {
+				continue
+			}
+
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), tz)
+
+			if convertDatesToUTC {
+				t = t.UTC()
+			}
+
+			dates = append(dates, t)
 		}
-
-		t, err := time.Parse(icsFormat, dt)
-		if err != nil {
-			return nil, err
-		}
-
-		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), tz)
-
-		if convertDatesToUTC {
-			t = t.UTC()
-		}
-
-		dates = append(dates)
 	}
 
 	return dates, nil

--- a/parse_test.go
+++ b/parse_test.go
@@ -125,7 +125,7 @@ func TestParseEventDate(t *testing.T) {
 
 	expected := time.Date(2015, time.Month(9), 30, 15, 0, 0, 0, loc)
 	dataStart := "DTSTART;TZID=Europe/Madrid:20150930T150000\n"
-	result, err := parseEventDate("DTSTART", dataStart)
+	result, _, err := parseEventDate("DTSTART", dataStart)
 	if err != nil {
 		t.FailNow()
 	}
@@ -135,7 +135,7 @@ func TestParseEventDate(t *testing.T) {
 	}
 
 	dataEnd := "DTEND;TZID=Europe/Madrid:20150930T150000\n"
-	result, err = parseEventDate("DTEND", dataEnd)
+	result, _, err = parseEventDate("DTEND", dataEnd)
 	if err != nil {
 		t.FailNow()
 	}
@@ -153,7 +153,7 @@ func TestParseEventRecurrenceID(t *testing.T) {
 	expected := time.Date(2015, time.Month(10), 13, 15, 0, 0, 0, loc)
 	data := "RECURRENCE-ID;TZID=Europe/Madrid:20151013T150000\n"
 
-	result, err := parseEventRecurrenceID(data)
+	result, _, err := parseEventRecurrenceID(data)
 	if err != nil {
 		t.Error(err)
 	}
@@ -190,7 +190,7 @@ END:VEVENT
 `
 
 func TestParseEventDateWholeDay(t *testing.T) {
-	tResult, err := parseEventDate("DTSTART", testWholeDayEvent)
+	tResult, _, err := parseEventDate("DTSTART", testWholeDayEvent)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Due to Go's way of handling dates location, it is necessary to not use any location info when the lib builds the dates, letting the users of the lib handle the location, UTC conversion and any other timezone parsing themselves.